### PR TITLE
Use RDNN icon name

### DIFF
--- a/data/notifications.metainfo.xml.in
+++ b/data/notifications.metainfo.xml.in
@@ -6,7 +6,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
 
-  <icon type="stock">preferences-system-notifications</icon>
+  <icon type="stock">io.elementary.notifications</icon>
   <name>Notifications Settings</name>
   <summary>Configure notification bubbles, sounds, and notification center</summary>
 

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -20,7 +20,7 @@ public class NotificationsPlug : Switchboard.Plug {
                 code_name: "io.elementary.settings.notifications",
                 display_name: _("Notifications"),
                 description: _("Configure notification bubbles, sounds, and notification center"),
-                icon: "preferences-system-notifications",
+                icon: "io.elementary.notifications",
                 supported_settings: settings);
     }
 


### PR DESCRIPTION
This is a non-fd.o icon name. Instead use the RDNN'd icon name provided by the notification server (which we depend on in this package)

Depends on https://github.com/elementary/notifications/pull/294